### PR TITLE
Add Ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,9 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install native dependencies
+        run: sudo apt-get install libclang-dev
+
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -89,6 +92,10 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      - name: Install native dependencies
+        if: matrix.os == 'ubuntu-20.04'
+        run: sudo apt-get install libclang-dev
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,11 +109,14 @@ jobs:
           command: build
           args: --release
       
-      - name: Build a .deb file
+      - name: Install cargo dev
         if: matrix.os == 'ubuntu-20.04'
         uses: actions-rs/install@v1
         with:
           crate: cargo-deb
+
+      - name: Build a .deb file
+        if: matrix.os == 'ubuntu-20.04'
         run: cargo deb
 
       - name: Save build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
           command: build
           args: --release
       
-      - name: Install cargo dev
+      - name: Install cargo deb
         if: matrix.os == 'ubuntu-20.04'
         uses: actions-rs/install@v0.1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
       
       - name: Install cargo dev
         if: matrix.os == 'ubuntu-20.04'
-        uses: actions-rs/install@v1
+        uses: actions-rs/install@v0.1
         with:
           crate: cargo-deb
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,13 @@ jobs:
         with:
           command: build
           args: --release
+      
+      - name: Build a .deb file
+        if: matrix.os == 'ubuntu-20.04'
+        uses: actions-rs/install@v1
+        with:
+          crate: cargo-deb
+        run: cargo deb
 
       - name: Save build
         uses: actions/upload-artifact@v2
@@ -116,4 +123,5 @@ jobs:
           path: |
             target/release/polite-c
             target/release/polite-c.exe
+            target/debian/*.deb
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,5 +123,6 @@ jobs:
           path: |
             target/release/polite-c
             target/release/polite-c.exe
+            target/release/*.dll
             target/debian/*.deb
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Install native dependencies
         run: sudo apt-get install libclang-dev
 
-      - name: Run cargo check
+      - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
 
   coverage:
     name: Code coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
 
   lints:
     name: Lints
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install native dependencies
+        run: sudo apt-get install libclang-dev
+
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
 
@@ -60,6 +63,9 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      - name: Install native dependencies
+        run: sudo apt-get install libclang-dev
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,10 +114,26 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-deb
+      
+      - name: Install the Wix toolset
+        if: matrix.os == 'window-2019'
+        run: choco install wixtoolset
+
+      - name: Install cargo wix
+        if: matrix.os == 'windows-2019'
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-wix
 
       - name: Build a .deb file
         if: matrix.os == 'ubuntu-20.04'
         run: cargo deb
+
+      - name: Build a .msi file
+        if: matrix.os == 'windows-2019'
+        run: |
+          cargo wix init
+          cargo wix
 
       - name: Save build
         uses: actions/upload-artifact@v2
@@ -128,4 +144,5 @@ jobs:
             target/release/polite-c.exe
             target/release/*.dll
             target/debian/*.deb
+            target/wix/*.msi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,106 @@
+name: Main workflow
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  coverage:
+    name: Code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macos-11.0
+          - windows-2019
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Save build
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-${{ matrix.os }}
+          path: |
+            target/release/polite-c
+            target/release/polite-c.exe
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ clang = { version = "1.0", features = ["clang_10_0"] }
 lazy_static = "1.4"
 make-u-move = { git = "https://github.com/WartaPoirier-corp/make-u-move", rev = "8f1077be7f2c8de062c906e863259f55a8ca7432" }
 petgraph = "0.5"
+
+[package.metadata.deb]
+depends = [ "libclang1-10", "libffi7", "libbsd0" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ make-u-move = { git = "https://github.com/WartaPoirier-corp/make-u-move", rev = 
 petgraph = "0.5"
 
 [package.metadata.deb]
-depends = "libclang1-10, libffi7, libbsd0"
+depends = "libclang1-10, libffi-dev, libbsd0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ make-u-move = { git = "https://github.com/WartaPoirier-corp/make-u-move", rev = 
 petgraph = "0.5"
 
 [package.metadata.deb]
-depends = [ "libclang1-10", "libffi7", "libbsd0" ]
+depends = "libclang1-10, libffi7, libbsd0"

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,5 +1,6 @@
 use clang::{Entity, EntityKind};
 use petgraph::prelude::*;
+use std::collections::LinkedList;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,6 +1,5 @@
 use clang::{Entity, EntityKind};
 use petgraph::prelude::*;
-use std::collections::LinkedList;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,6 +1,5 @@
 use clang::{Entity, EntityKind};
 use petgraph::prelude::*;
-use std::collections::LinkedList;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 
@@ -41,6 +40,7 @@ impl<'tu> std::fmt::Display for Node {
 
 /// Control-Flow Graph of a function's body
 pub struct CFG {
+    #[allow(dead_code)] // FIXME: temporary, until we have something more than a dot export
     graph: DiGraph<Node, Edge>,
 }
 
@@ -52,7 +52,7 @@ impl<'tu> TryFrom<clang::Entity<'tu>> for CFG {
             return Err(());
         }
 
-        let args = function.get_arguments().unwrap(); // TODO don't unwrap
+        let _args = function.get_arguments().unwrap(); // TODO don't unwrap
         let root_stmt = function
             .get_children()
             .iter()
@@ -78,7 +78,7 @@ impl<'tu> TryFrom<clang::Entity<'tu>> for CFG {
             graph: &mut DiGraph<Node, Edge>,
             next: NodeIndex,
             break_to: NodeIndex,
-            mut statements: Vec<Entity>,
+            statements: Vec<Entity>,
         ) -> NodeIndex {
             println!(
                 "{}",
@@ -110,7 +110,7 @@ impl<'tu> TryFrom<clang::Entity<'tu>> for CFG {
                         // FIXME might by a compound statement ?
                         let stmt_init = graph.add_node(Node::from(entity.get_child(0).unwrap()));
                         // FIXME might by a compound statement ?
-                        let stmt_cond = entity.get_child(1).unwrap();
+                        let _stmt_cond = entity.get_child(1).unwrap();
                         // FIXME might by a compound statement ?
                         let stmt_after = graph.add_node(Node::from(entity.get_child(2).unwrap()));
                         let stmt_block = entity.get_child(3).unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,7 +145,7 @@ impl FromStr for CFileLocation {
             });
         }
 
-        Err(CFileLocationParseError::InvalidFormat)
+        return Err(CFileLocationParseError::InvalidFormat);
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,7 +145,7 @@ impl FromStr for CFileLocation {
             });
         }
 
-        return Err(CFileLocationParseError::InvalidFormat);
+        Err(CFileLocationParseError::InvalidFormat)
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,7 @@ pub struct CFileLocation {
 }
 
 impl CFileLocation {
+    #[cfg(feature = "dot")]
     pub fn find<'tu>(
         &self,
         tu: clang::Entity<'tu>, // index: &'tu clang::Index<'tu>,
@@ -145,7 +146,7 @@ impl FromStr for CFileLocation {
             });
         }
 
-        return Err(CFileLocationParseError::InvalidFormat);
+        Err(CFileLocationParseError::InvalidFormat)
     }
 }
 
@@ -184,6 +185,7 @@ pub struct Args {
 }
 
 impl Args {
+    #[cfg(feature = "dot")]
     pub fn parse() -> Self {
         Clap::parse()
     }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::path::PathBuf;
 
 pub struct Span {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,10 @@ mod cfg;
 mod cli;
 mod diagnostics;
 
-use crate::cfg::CFG;
 use crate::cli::Args;
 use clang::documentation::{CommentChild, ParamCommand};
 use clang::{Clang, EntityKind, EntityVisitResult, Index};
-use std::convert::TryFrom;
 use std::ops::Range;
-use std::path::Path;
 
 fn make_ascii_title_case(s: &mut str) {
     if let Some(s) = s.get_mut(0..1) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,13 @@ mod cfg;
 mod cli;
 mod diagnostics;
 
+use crate::cfg::CFG;
 use crate::cli::Args;
 use clang::documentation::{CommentChild, ParamCommand};
 use clang::{Clang, EntityKind, EntityVisitResult, Index};
+use std::convert::TryFrom;
 use std::ops::Range;
+use std::path::Path;
 
 fn make_ascii_title_case(s: &mut str) {
     if let Some(s) = s.get_mut(0..1) {


### PR DESCRIPTION
> Moi dans mon temps libre je lance des VMs sous Ubuntu dans le cloud pour vérifier qu'un saut de ligne se trouve bien à la fin de chaque fichier, et j'adore ce *workflow*

Sauf que ça fait plus que vérifier les sauts de ligne, et que c'est pas juste des VM Ubuntu ! En résumé : 

- `cargo test`
- rustfmt
- clippy
- `cargo build`, pour Ubuntu, Mac OS X et Windows. Les exécutables sont sauvegardés. Je pense que pour Windows il va manquer la DLL de clang, mais je vais l'ajouter. Je vais voir pour faire un .deb avec cargo-deb aussi, parce qu'il faut `apt install libclang` à  la main pour le moment
- `cargo tarpaulin` pour le coverage, avec la mise en ligne sur Codecov.io
- les erreurs sont affichées dans des commentaires de PR normalement, pour éviter de devoir checker les logs à la main

TODO:

- [x] ~~la DLL~~ update : pas besoin, faut juste bien installer llvm/clang avant, j'ai fait un README pour expliquer comment faire
- [x] le .deb
- [x] rendre clippy heureux
- [x] tenter de faire un MSI